### PR TITLE
Change initial PR message for PyProject.toml

### DIFF
--- a/templates/add-toml.md
+++ b/templates/add-toml.md
@@ -1,14 +1,17 @@
 # Add pyproject.toml for Custom Node Registry
 
-We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.
+We are building a global registry for custom nodes (similar to PyPI) with dr.lt.data and comfyanon. Eventually, the registry will be used as a backend for the UI-manager. All nodes will go through a verification proess before being published to users.
 
-Here’s some [more information](https://comfydocs.org/registry/overview#introduction) on the registry.
+The main benefits are that authors can
+- publish nodes by version, and users can safely update nodes knowing their workflows won't break. 
+- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard
 
 Action Required:
 
-- [ ] Go to the [registry](https://comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
-- [ ] Write a short the description.
+- [ ] Go to the [registry](https://comfyregistry.org/). Login and create a publisher id. Add the publisher id into the pyproject.toml file.
+- [ ] Write a short description.
 - [ ] Merge the separate Github Actions PR and run the workflow.
 
 If you want to publish the node manually, [install the cli](https://comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`
-Please message me on [Discord](https://discord.com/invite/comfyorg) if you have any questions!
+
+Check out our [docs](https://comfydocs.org/registry/overview#introduction) page or message me on [Discord](https://discord.com/invite/comfyorg) if you have any questions!


### PR DESCRIPTION
This is what the new PR template would look like! Lmk what you guys think!

# Add pyproject.toml for Custom Node Registry

We are building a global registry for custom nodes (similar to PyPI) with dr.lt.data and comfyanon. Eventually, the registry will be used as a backend for the UI-manager. All nodes will go through a verification proess before being published to users.

The main benefits are that authors can
- publish nodes by version, and users can safely update nodes knowing their workflows won't break. 
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://comfyregistry.org/). Login and create a publisher id. Add the publisher id into the pyproject.toml file.
- [ ] Write a short description.
- [ ] Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`

Check out our [docs](https://comfydocs.org/registry/overview#introduction) page or message me on [Discord](https://discord.com/invite/comfyorg) if you have any questions!